### PR TITLE
Fix a bug for fast_cumsum_sub_one of Tutel

### DIFF
--- a/tutel/jit_kernels/gating.py
+++ b/tutel/jit_kernels/gating.py
@@ -60,6 +60,7 @@ def get_cumsum_kernel(samples, global_experts):
             __syncthreads();
             if (S + thid < @num_samples@)
                     output0[thid * batch_num + bid] = temp[thid + 1] + last_sum;
+            __syncthreads();
             last_sum += temp[thread_num];
         }
     }


### PR DESCRIPTION
Fix a synchronize problem in fast_cumsum_sub_one. 

For thread i, temp[thid + 1] (in line 62) will be incorrect if thread i+1 goes faster (to the next iteration in line 40). This will cause incorrect assignment in line 62.

To reproduce the problem, please try the following code,
```
locations1 = fast_cumsum_sub_one(mask1, dim=0)
locations1_2 = fast_cumsum_sub_one(mask1, dim=0)
print("shape of mask1 = {}, dtype of mask1 = {}".format(mask1.shape, mask1.dtype))
for ii in range(locations1.shape[0]):
    if not torch.equal(locations1[ii, :], locations1_2[ii, :]):
        print(ii, locations1[ii, :].tolist(), locations1_2[ii, :].tolist())
```
```
----- OUTPUT -----
shape of mask1 = torch.Size([3136, 8]), dtype of mask1 = torch.int64
31 [5, -1, 1, 1, 4, 3, 2, 2] [5, 6, 1, 1, 4, 3, 2, 2]
159 [12, 18, 14, 5, 13, 66, 12, 12] [12, -1, 14, 5, 13, 66, 12, 12]
351 [14, 21, 17, 6, 17, 234, 13, 22] [14, 21, -1, 6, 17, 234, 13, 22]
383 [14, 21, 19, 6, 17, -1, 13, 23] [14, 21, 19, 6, -1, -1, 13, 23]
511 [16, 23, 23, -1, 19, 368, 20, 27] [16, 23, 23, 8, 19, 368, 20, 27]
639 [57, 39, 25, 10, 21, 421, 29, 30] [57, 39, -1, 10, 21, 421, 29, 30]
895 [199, 44, 25, 10, 24, 518, 29, 39] [-1, 44, 25, 10, 24, 518, 29, 39]
1055 [208, 64, 28, 14, 29, 613, 30, 57] [208, 64, 28, 14, 34, 613, 30, 52]
1087 [213, 67, 30, 14, 43, 619, 31, 63] [213, 67, 30, 13, 43, 619, 31, 63]
1119 [219, 76, 31, 14, 48, 625, 31, 68] [206, 76, 31, 14, 48, 625, 31, 68]
1151 [231, 84, 32, 16, 49, 630, 31, 71] [231, 60, 28, 16, 28, 630, 30, 52]
1183 [239, 94, 32, 18, 52, 637, 31, 73] [239, 60, 32, 18, 52, 637, 31, 73]
1215 [241, 96, 32, 18, 52, 665, 31, 73] [241, 96, 32, 18, 52, 665, 30, 73]
1247 [241, 96, 32, 19, 52, 694, 32, 74] [206, 60, 32, 19, 52, 694, 32, 74]
1311 [241, 101, 33, 19, 28, 750, 32, 76] [241, 101, 33, 19, 52, 750, 32, 76]
1343 [242, 101, 38, 20, 53, 770, 35, 77] [242, 101, 38, 13, 53, 770, 35, 77]
1407 [248, 109, 43, 21, 54, 807, 39, 79] [248, 109, 28, 21, 28, 807, 39, 79]
1567 [274, 60, 67, 33, 62, 835, 74, 83] [274, 132, 67, 33, 62, 835, 74, 83]
1599 [277, 136, 72, 35, 62, 850, 77, 83] [277, 136, 72, 13, 62, 850, 77, 83]
1631 [282, 140, 74, 37, 62, 600, 81, 84] [282, 140, 74, 37, 62, 864, 81, 84]
1759 [310, 161, 98, 47, 69, 874, 106, 87] [310, 161, 98, 47, 69, 600, 106, 87]
1823 [311, 165, 98, 49, 28, 927, 108, 88] [311, 165, 98, 49, 70, 927, 108, 88]
1855 [311, 165, 98, 49, 70, 959, 108, 88] [311, 165, 98, 49, 70, 600, 108, 88]
1887 [311, 167, 98, 49, 70, 989, 108, 88] [206, 167, 98, 49, 70, 989, 108, 88]
1951 [312, 169, 103, 51, 72, 1035, 111, 91] [312, 60, 103, 51, 72, 1035, 111, 91]
----- End -----
```
