### PR TITLE
Add Feature - Support overlapping all-to-all with FFN computation in MoE layer

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,8 +53,11 @@ class Tester(Command):
 def install(use_nccl):
     ext_libs = ['dl', 'cuda', 'nvrtc'] if not IS_HIP_EXTENSION else []
     ext_args = {'cxx': ['-Wno-sign-compare', '-Wno-unused-but-set-variable']}
-    if use_nccl and not IS_HIP_EXTENSION:
-        ext_libs += ['nccl']
+    if use_nccl:
+        if IS_HIP_EXTENSION:
+            ext_libs += ['rccl']
+        else:
+            ext_libs += ['nccl']
         ext_args['cxx'] += ['-DUSE_NCCL']
 
     setup(

--- a/tests/test_tutel.py
+++ b/tests/test_tutel.py
@@ -20,16 +20,17 @@ class HelloworldCaller():
         show_step_time=True,
         batch_size=16,
         is_round=True,
-        a2a_ffn_overlap_degree=1
+        a2a_ffn_overlap_degree=1,
+        num_steps=100
         ):
         # Disable NCCL SHM because it's capacity is limited in Azure pipeline
         new_env = os.environ.copy()
         new_env['NCCL_SHM_DISABLE'] = '1'
         """Run helloworld example"""
         if helloworld_file == 'helloworld':
-            command = 'python3 -m torch.distributed.launch --nproc_per_node=' + str(nproc_per_node) + ' tutel/examples/helloworld.py --top ' + str(top) + ' --dtype ' + dtype + ' --num_local_experts ' + str(num_local_experts) + ' --hidden_size ' + str(hidden_size) + ' --batch_size ' + str(batch_size) + ' --a2a_ffn_overlap_degree ' + str(a2a_ffn_overlap_degree)
+            command = 'python3 -m torch.distributed.launch --nproc_per_node=' + str(nproc_per_node) + ' tutel/examples/helloworld.py --top ' + str(top) + ' --dtype ' + dtype + ' --num_local_experts ' + str(num_local_experts) + ' --hidden_size ' + str(hidden_size) + ' --batch_size ' + str(batch_size) + ' --a2a_ffn_overlap_degree ' + str(a2a_ffn_overlap_degree) + ' --num_steps ' + str(num_steps)
         if helloworld_file == 'helloworld_megatron':
-            command = 'python3 -m torch.distributed.launch --nproc_per_node=' + str(nproc_per_node) + ' tutel/examples/helloworld_megatron.py --dtype ' + dtype + ' --num_local_experts ' + str(num_local_experts) + ' --hidden_size ' + str(hidden_size) + ' --batch_size ' + str(batch_size)
+            command = 'python3 -m torch.distributed.launch --nproc_per_node=' + str(nproc_per_node) + ' tutel/examples/helloworld_megatron.py --dtype ' + dtype + ' --num_local_experts ' + str(num_local_experts) + ' --hidden_size ' + str(hidden_size) + ' --batch_size ' + str(batch_size) + ' --num_steps ' + str(num_steps)
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=new_env)
         losses = []
         while p.poll() is None:
@@ -133,16 +134,16 @@ class TutelTestCase(unittest.TestCase):
     def test_a2a_ffn_overlap(self):
         """Test whether AllToAll-FFN overlapping works properly. Note that too small batch size might cause precision issue."""
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1, num_steps=10),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2, num_steps=10)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1, num_steps=10),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2, num_steps=10)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1, num_steps=10),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2, num_steps=10)
             )

--- a/tests/test_tutel.py
+++ b/tests/test_tutel.py
@@ -129,16 +129,16 @@ class TutelTestCase(unittest.TestCase):
     def test_a2a_ffn_overlap(self):
         """Test whether AllToAll-FFN overlapping works properly. Note that too small batch size might cause precision issue."""
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
             )

--- a/tests/test_tutel.py
+++ b/tests/test_tutel.py
@@ -128,18 +128,18 @@ class TutelTestCase(unittest.TestCase):
             )
 
     def test_a2a_ffn_overlap(self):
-        """Test whether AllToAll-FFN overlapping works properly"""
+        """Test whether AllToAll-FFN overlapping works properly. Note that too small batch size might cause precision issue."""
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
             )

--- a/tests/test_tutel.py
+++ b/tests/test_tutel.py
@@ -128,10 +128,10 @@ class TutelTestCase(unittest.TestCase):
 
     def test_a2a_ffn_overlap(self):
         """Test whether AllToAll-FFN overlapping works properly. Note that too small batch size might cause precision issue."""
-        # self.assertEqual(
-        #     self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
-        #     self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
-        #     )
+        self.assertEqual(
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
+            )
 
         self.assertEqual(
             self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),

--- a/tests/test_tutel.py
+++ b/tests/test_tutel.py
@@ -128,17 +128,17 @@ class TutelTestCase(unittest.TestCase):
 
     def test_a2a_ffn_overlap(self):
         """Test whether AllToAll-FFN overlapping works properly. Note that too small batch size might cause precision issue."""
+        # self.assertEqual(
+        #     self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+        #     self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
+        #     )
+
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
-            )
-
-        self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
             )

--- a/tests/test_tutel.py
+++ b/tests/test_tutel.py
@@ -133,16 +133,16 @@ class TutelTestCase(unittest.TestCase):
     def test_a2a_ffn_overlap(self):
         """Test whether AllToAll-FFN overlapping works properly. Note that too small batch size might cause precision issue."""
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2)
             )

--- a/tests/test_tutel.py
+++ b/tests/test_tutel.py
@@ -26,7 +26,6 @@ class HelloworldCaller():
             command = 'python3 -m torch.distributed.launch --nproc_per_node=' + str(nproc_per_node) + ' tutel/examples/helloworld.py --top ' + str(top) + ' --dtype ' + dtype + ' --num_local_experts ' + str(num_local_experts) + ' --hidden_size ' + str(hidden_size) + ' --batch_size ' + str(batch_size) + ' --a2a_ffn_overlap_degree ' + str(a2a_ffn_overlap_degree)
         if helloworld_file == 'helloworld_megatron':
             command = 'python3 -m torch.distributed.launch --nproc_per_node=' + str(nproc_per_node) + ' tutel/examples/helloworld_megatron.py --dtype ' + dtype + ' --num_local_experts ' + str(num_local_experts) + ' --hidden_size ' + str(hidden_size) + ' --batch_size ' + str(batch_size)
-        print(command)
         p = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         losses = []
         while p.poll() is None:

--- a/tutel/custom/custom_kernel.cpp
+++ b/tutel/custom/custom_kernel.cpp
@@ -286,7 +286,7 @@ static torch::Tensor& current_stream_acquire(torch::Tensor &tensor, int idx) {
   return tensor;
 }
 
-static std::vector<torch::Tensor> nccl_all_to_all_scatter_async(
+static void nccl_all_to_all_scatter_async(
     const torch::Tensor &input,
     std::vector<torch::Tensor> &output_list,
     bool is_backward) {
@@ -337,11 +337,9 @@ static std::vector<torch::Tensor> nccl_all_to_all_scatter_async(
     // Release calc_idx-th event
     g_cuda_events[calc_idx].record(get_nccl_stream());
   }
-
-  return output_list;
 }
 
-static torch::Tensor nccl_all_to_all_gather_async(
+static void nccl_all_to_all_gather_async(
     const std::vector<torch::Tensor> &input_list,
     torch::Tensor &output,
     bool is_backward) {
@@ -392,8 +390,6 @@ static torch::Tensor nccl_all_to_all_gather_async(
 
   // Release 0-th event for single output
   g_cuda_events[0].record(get_nccl_stream());
-
-  return output;
 }
 
 #endif

--- a/tutel/custom/custom_kernel.cpp
+++ b/tutel/custom/custom_kernel.cpp
@@ -3,6 +3,8 @@
 
 #include <torch/extension.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/cuda/CUDAEvent.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 
 #if defined(USE_NCCL)
 #include <nccl.h>
@@ -20,11 +22,13 @@
 
 #undef CHECK_EQ
 #undef CHECK_NE
+#undef CHECK_CPU
 #undef CHECK_CUDA
 #undef CHECK_CONTIGUOUS
 
 #define CHECK_EQ(x, y) AT_ASSERTM((x) == (y), "CHECK_EQ fails.")
 #define CHECK_NE(x, y) AT_ASSERTM((x) != (y), "CHECK_NE fails.")
+#define CHECK_CPU(x) AT_ASSERTM(!x.is_cuda(), #x " must be a CPU tensor")
 #define CHECK_CUDA(x) AT_ASSERTM(x.is_cuda(), #x " must be a CUDA tensor")
 #define CHECK_CONTIGUOUS(x) AT_ASSERTM(x.is_contiguous(), #x " must be contiguous")
 
@@ -226,49 +230,172 @@ static void invoke_with_source(const std::vector<torch::Tensor> &ts, int code_id
 
 
 #if defined(USE_NCCL)
-static torch::Tensor external_all2all(const torch::Tensor &tensor, int stage) {
-  // Designed for older Pytorch without dist.alltoall() support
-  static ncclComm_t comm;
-  static int world_size, world_rank, local_rank;
-  auto tensor_ptr = (char*)tensor.data_ptr();
 
-  if (~stage) {
-    ncclUniqueId id;
-    if (stage == 0) {
-      CHECK_EQ(0, ncclGetUniqueId(&id));
-      memcpy(tensor_ptr, &id, sizeof(id));
-    } else {
-      world_size = getenv("WORLD_SIZE") ? std::atoi(getenv("WORLD_SIZE")) : 1;
-      world_rank = getenv("RANK") ? std::atoi(getenv("RANK")) : 0;
-      local_rank = getenv("LOCAL_RANK") ? std::atoi(getenv("LOCAL_RANK")) : 0;
+static ncclComm_t g_nccl_comm;
+static std::vector<at::cuda::CUDAEvent> g_cuda_events;
+static int g_num_split = 0;
+static int g_num_slices_per_split = 0;
+static int g_world_size = 0;
 
-      memcpy(&id, tensor_ptr, sizeof(id));
+static size_t get_nccl_unique_id_size() {
+  return sizeof(ncclUniqueId);
+}
 
-      CHECK_EQ(0, ncclGroupStart());
-      CHECK_EQ(0, ncclCommInitRank(&comm, world_size, id, world_rank));
-      CHECK_EQ(0, ncclGroupEnd());
-    }
-    return tensor;
-  }
+static void get_nccl_unique_id(torch::Tensor &nccl_unique_id_tensor) {
+  ncclUniqueId nccl_unique_id;
 
-  CHECK_CUDA(tensor);
-  // CHECK_EQ(0, cudaStreamSynchronize(nullptr));
+  CHECK_EQ(0, ncclGetUniqueId(&nccl_unique_id));
+  CHECK_CPU(nccl_unique_id_tensor);
+  CHECK_EQ(nccl_unique_id_tensor.nbytes(), sizeof(ncclUniqueId));
+  memcpy((void *)nccl_unique_id_tensor.data_ptr(), &nccl_unique_id, sizeof(ncclUniqueId));
+}
 
-  size_t length = tensor.nbytes(), slice_size = length / world_size;
-  CHECK_EQ(0, length % world_size);
+static void init_nccl(
+    const torch::Tensor &nccl_unique_id_tensor,
+    int world_size,
+    int world_rank,
+    int num_split,
+    int num_slices_per_split) {
+  ncclUniqueId nccl_unique_id;
 
-  auto output = torch::empty_like(tensor, torch::MemoryFormat::Contiguous);
-
+  CHECK_CPU(nccl_unique_id_tensor);
+  CHECK_EQ(nccl_unique_id_tensor.nbytes(), sizeof(ncclUniqueId));
+  memcpy(&nccl_unique_id, (void *)nccl_unique_id_tensor.data_ptr(), sizeof(ncclUniqueId));
   CHECK_EQ(0, ncclGroupStart());
-  for (int r = 0; r < world_size; r++) {
-    CHECK_EQ(0, ncclSend(tensor_ptr + r * slice_size, slice_size, ncclInt8, r, comm, nullptr));
-    CHECK_EQ(0, ncclRecv(((char*)output.data_ptr()) + r * slice_size, slice_size, ncclInt8, r, comm, nullptr));
-  }
+  CHECK_EQ(0, ncclCommInitRank(&g_nccl_comm, world_size, nccl_unique_id, world_rank));
   CHECK_EQ(0, ncclGroupEnd());
 
-  // CHECK_EQ(0, cudaStreamSynchronize(nullptr));
+  g_num_split = num_split;
+  g_cuda_events.resize(num_split);
+  g_num_slices_per_split = num_slices_per_split;
+  g_world_size = world_size;
+}
+
+static at::cuda::CUDAStream& get_nccl_stream() {
+  static at::cuda::CUDAStream nccl_stream = at::cuda::getStreamFromPool();
+  return nccl_stream;
+}
+
+static torch::Tensor& current_stream_release(torch::Tensor &tensor, int idx) {
+  g_cuda_events[idx].record(at::cuda::getCurrentCUDAStream());
+  return tensor;
+}
+
+static torch::Tensor& current_stream_acquire(torch::Tensor &tensor, int idx) {
+  g_cuda_events[idx].block(at::cuda::getCurrentCUDAStream());
+  return tensor;
+}
+
+static std::vector<torch::Tensor> nccl_all_to_all_scatter_async(
+    const torch::Tensor &input,
+    std::vector<torch::Tensor> &output_list,
+    bool is_backward) {
+  CHECK_CUDA(input);
+  CHECK_EQ(g_num_split, output_list.size());
+  for (auto& output : output_list) {
+    CHECK_CUDA(output);
+  }
+
+  CHECK_EQ(0, g_num_slices_per_split % g_world_size);
+  size_t length = input.nbytes();
+  size_t num_slices = g_num_slices_per_split * g_num_split;
+  CHECK_EQ(0, length % num_slices);
+  size_t slice_size = length / num_slices;
+
+  // Allocator will add blocking event to nccl stream after nccl kernels
+  c10::cuda::CUDACachingAllocator::recordStream(input.storage().data_ptr(), get_nccl_stream());
+  for (auto& output : output_list) {
+    c10::cuda::CUDACachingAllocator::recordStream(output.storage().data_ptr(), get_nccl_stream());
+  }
+
+  // Acquire 0-th event for single input
+  g_cuda_events[0].block(get_nccl_stream());
+
+  for (int i = 0; i < g_num_split; i++) {
+    // Reverse calculation order in backward for pipelining
+    int calc_idx = is_backward ? g_num_split - 1 - i : i;
+
+    CHECK_EQ(0, ncclGroupStart());
+    for (int j = 0; j < g_num_slices_per_split; j++) {
+      CHECK_EQ(0, ncclSend(
+          ((char*)input.data_ptr()) + (j * g_num_split + calc_idx) * slice_size,
+          slice_size,
+          ncclInt8,
+          g_world_size * j / g_num_slices_per_split,
+          g_nccl_comm,
+          get_nccl_stream().stream()));
+      CHECK_EQ(0, ncclRecv(
+          ((char*)output_list[calc_idx].data_ptr()) + j * slice_size,
+          slice_size,
+          ncclInt8,
+          g_world_size * j / g_num_slices_per_split,
+          g_nccl_comm,
+          get_nccl_stream().stream()));
+    }
+    CHECK_EQ(0, ncclGroupEnd());
+
+    // Release calc_idx-th event
+    g_cuda_events[calc_idx].record(get_nccl_stream());
+  }
+
+  return output_list;
+}
+
+static torch::Tensor nccl_all_to_all_gather_async(
+    const std::vector<torch::Tensor> &input_list,
+    torch::Tensor &output,
+    bool is_backward) {
+  CHECK_EQ(g_num_split, input_list.size());
+  for (auto& input : input_list) {
+    CHECK_CUDA(input);
+  }
+  CHECK_CUDA(output);
+
+  CHECK_EQ(0, g_num_slices_per_split % g_world_size);
+  size_t length = output.nbytes();
+  size_t num_slices = g_num_slices_per_split * g_num_split;
+  CHECK_EQ(0, length % num_slices);
+  size_t slice_size = length / num_slices;
+
+  // Allocator will add blocking event to nccl stream after nccl kernels
+  for (auto& input : input_list) {
+    c10::cuda::CUDACachingAllocator::recordStream(input.storage().data_ptr(), get_nccl_stream());
+  }
+  c10::cuda::CUDACachingAllocator::recordStream(output.storage().data_ptr(), get_nccl_stream());
+
+  for (int i = 0; i < g_num_split; i++) {
+    // Reverse calculation order in backward for pipelining
+    int calc_idx = is_backward ? g_num_split - 1 - i : i;
+
+    // Acquire calc_idx-th event
+    g_cuda_events[calc_idx].block(get_nccl_stream());
+
+    CHECK_EQ(0, ncclGroupStart());
+    for (int j = 0; j < g_num_slices_per_split; j++) {
+      CHECK_EQ(0, ncclSend(
+          ((char*)input_list[calc_idx].data_ptr()) + j * slice_size,
+          slice_size,
+          ncclInt8,
+          g_world_size * j / g_num_slices_per_split,
+          g_nccl_comm,
+          get_nccl_stream().stream()));
+      CHECK_EQ(0, ncclRecv(
+          ((char*)output.data_ptr()) + (j * g_num_split + calc_idx) * slice_size,
+          slice_size,
+          ncclInt8,
+          g_world_size * j / g_num_slices_per_split,
+          g_nccl_comm,
+          get_nccl_stream().stream()));
+    }
+    CHECK_EQ(0, ncclGroupEnd());
+  }
+
+  // Release 0-th event for single output
+  g_cuda_events[0].record(get_nccl_stream());
+
   return output;
 }
+
 #endif
 
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
@@ -281,9 +408,33 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
         "Generic Invoke with Source (CUDA)"
     );
 #if defined(USE_NCCL)
-    m.def("external_all2all",
-        &external_all2all,
-        "External AllToAll for Pytorch without builtin dist.alltoall (CUDA)"
+    m.def("get_nccl_unique_id_size",
+        &get_nccl_unique_id_size,
+        "Get size of ncclUniqueId in bytes"
+    );
+    m.def("get_nccl_unique_id",
+        &get_nccl_unique_id,
+        "Get ncclUniqueId for NCCL initialization"
+    );
+    m.def("init_nccl",
+        &init_nccl,
+        "NCCL initialization"
+    );
+    m.def("current_stream_release",
+        &current_stream_release,
+        "Record CUDA event on current stream to i-th event slot"
+    );
+    m.def("current_stream_acquire",
+        &current_stream_acquire,
+        "Let current stream wait CUDA event in i-th event slot"
+    );
+    m.def("nccl_all_to_all_scatter_async",
+        &nccl_all_to_all_scatter_async,
+        "NCCL AllToAll (Scatter Async)"
+    );
+    m.def("nccl_all_to_all_gather_async",
+        &nccl_all_to_all_gather_async,
+        "NCCL AllToAll (Gather Async)"
     );
 #endif
 }

--- a/tutel/examples/helloworld.py
+++ b/tutel/examples/helloworld.py
@@ -31,6 +31,7 @@ parser.add_argument('--fp32_gate', default=False, action='store_true')
 parser.add_argument('--top', type=int, default=2)
 parser.add_argument('--l_aux_wt', type=float, default=0.0)
 parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
+parser.add_argument('--num_steps', type=int, default=100)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -93,7 +94,7 @@ y = torch.LongTensor(batch_size).random_(1).to(device)
 tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, a2a_ffn_overlap_degree, device)
 dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, a2a_ffn_overlap_degree = %s, device = `%s`' % tuples)
 
-average_time, num_steps = 0, 100
+average_time, num_steps = 0, args.num_steps
 
 params_for_all_reduce = [p for p in model.parameters() if not hasattr(p, 'skip_allreduce') and getattr(p, 'requires_grad', False) and p.grad is not None]
 

--- a/tutel/examples/helloworld_amp.py
+++ b/tutel/examples/helloworld_amp.py
@@ -31,6 +31,7 @@ parser.add_argument('--dtype', type=str, default='float32')
 parser.add_argument('--fp32_gate', default=False, action='store_true')
 parser.add_argument('--top', type=int, default=2)
 parser.add_argument('--l_aux_wt', type=float, default=0.0)
+parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -43,6 +44,7 @@ model_dim = args.model_dim
 hidden_size = args.hidden_size
 num_local_experts = args.num_local_experts
 top_value = args.top
+a2a_ffn_overlap_degree = args.a2a_ffn_overlap_degree
 device = parallel_env.local_device
 
 if args.dtype == 'float32':
@@ -67,6 +69,7 @@ class ExampleModel(torch.nn.Module):
             model_dim = model_dim,
             scan_expert_func = lambda name, param: setattr(param, 'skip_allreduce', True),
             seeds = (1, dist_rank + 1, 1),
+            a2a_ffn_overlap_degree = a2a_ffn_overlap_degree,
         ).to(device)
 
         # Summary of different parameter types: gate, local_experts
@@ -88,8 +91,8 @@ torch.manual_seed(0)
 x = torch.tensor(torch.randn([batch_size, num_tokens, model_dim], dtype=torch.float32, device='cpu').detach().numpy(), dtype=torch.get_default_dtype(), requires_grad=True, device=device)
 y = torch.LongTensor(batch_size).random_(1).to(device)
 
-tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, device)
-dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, device = `%s`' % tuples)
+tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, a2a_ffn_overlap_degree, device)
+dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, a2a_ffn_overlap_degree = %s, device = `%s`' % tuples)
 
 average_time, num_steps = 0, 100
 

--- a/tutel/examples/helloworld_amp.py
+++ b/tutel/examples/helloworld_amp.py
@@ -32,6 +32,7 @@ parser.add_argument('--fp32_gate', default=False, action='store_true')
 parser.add_argument('--top', type=int, default=2)
 parser.add_argument('--l_aux_wt', type=float, default=0.0)
 parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
+parser.add_argument('--num_steps', type=int, default=100)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -94,7 +95,7 @@ y = torch.LongTensor(batch_size).random_(1).to(device)
 tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, a2a_ffn_overlap_degree, device)
 dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, a2a_ffn_overlap_degree = %s, device = `%s`' % tuples)
 
-average_time, num_steps = 0, 100
+average_time, num_steps = 0, args.num_steps
 
 params_for_all_reduce = [p for p in model.parameters() if not hasattr(p, 'skip_allreduce') and getattr(p, 'requires_grad', False) and p.grad is not None]
 

--- a/tutel/examples/helloworld_data_model.py
+++ b/tutel/examples/helloworld_data_model.py
@@ -32,6 +32,7 @@ parser.add_argument('--top', type=int, default=2)
 parser.add_argument('--l_aux_wt', type=float, default=0.0)
 parser.add_argument('--group_count', type=int, default=1)
 parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
+parser.add_argument('--num_steps', type=int, default=100)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -98,7 +99,7 @@ y = torch.LongTensor(batch_size).random_(1).to(device)
 tuples = (parallel_env.global_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, a2a_ffn_overlap_degree, device, parallel_env.group_count)
 dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, a2a_ffn_overlap_degree = %s, device = `%s`, group_count = %s' % tuples)
 
-average_time, num_steps = 0, 100
+average_time, num_steps = 0, args.num_steps
 
 params_for_all_reduce = [p for p in model.parameters() if not hasattr(p, 'skip_allreduce') and getattr(p, 'requires_grad', False) and p.grad is not None]
 params_for_replicas_all_reduce = [p for p in model.parameters() if not (not hasattr(p, 'skip_allreduce') and getattr(p, 'requires_grad', False) and p.grad is not None)]

--- a/tutel/examples/helloworld_data_model.py
+++ b/tutel/examples/helloworld_data_model.py
@@ -31,6 +31,7 @@ parser.add_argument('--fp32_gate', default=False, action='store_true')
 parser.add_argument('--top', type=int, default=2)
 parser.add_argument('--l_aux_wt', type=float, default=0.0)
 parser.add_argument('--group_count', type=int, default=1)
+parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -46,6 +47,7 @@ model_dim = args.model_dim
 hidden_size = args.hidden_size
 num_local_experts = args.num_local_experts
 top_value = args.top
+a2a_ffn_overlap_degree = args.a2a_ffn_overlap_degree
 device = torch.device('cuda', args.local_rank)
 
 if args.dtype == 'float32':
@@ -71,6 +73,7 @@ class ExampleModel(torch.nn.Module):
             scan_expert_func = lambda name, param: setattr(param, 'skip_allreduce', True),
             seeds = (1, parallel_env.model_rank + 1, 1),
             group = parallel_env.model_group,
+            a2a_ffn_overlap_degree = a2a_ffn_overlap_degree,
         ).to(device)
 
         # Summary of different parameter types: gate, local_experts
@@ -92,8 +95,8 @@ torch.manual_seed(parallel_env.global_rank)
 x = torch.tensor(torch.randn([batch_size, num_tokens, model_dim], dtype=torch.float32, device='cpu').detach().numpy(), dtype=torch.get_default_dtype(), requires_grad=True, device=device)
 y = torch.LongTensor(batch_size).random_(1).to(device)
 
-tuples = (parallel_env.global_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, device, parallel_env.group_count)
-dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, device = `%s`, group_count = %s' % tuples)
+tuples = (parallel_env.global_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, a2a_ffn_overlap_degree, device, parallel_env.group_count)
+dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, a2a_ffn_overlap_degree = %s, device = `%s`, group_count = %s' % tuples)
 
 average_time, num_steps = 0, 100
 

--- a/tutel/examples/helloworld_ddp.py
+++ b/tutel/examples/helloworld_ddp.py
@@ -31,6 +31,7 @@ parser.add_argument('--num_local_experts', type=int, default=2)
 parser.add_argument('--dtype', type=str, default='float32')
 parser.add_argument('--fp32_gate', default=False, action='store_true')
 parser.add_argument('--top', type=int, default=2)
+parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -43,6 +44,7 @@ model_dim = args.model_dim
 hidden_size = args.hidden_size
 num_local_experts = args.num_local_experts
 top_value = args.top
+a2a_ffn_overlap_degree = args.a2a_ffn_overlap_degree
 device = parallel_env.local_device
 
 if args.dtype == 'float32':
@@ -68,6 +70,7 @@ class ExampleModel(torch.nn.Module):
             model_dim = model_dim,
             scan_expert_func = lambda name, param: setattr(param, 'skip_allreduce', True),
             seeds = (1, dist_rank + 1, 1),
+            a2a_ffn_overlap_degree = a2a_ffn_overlap_degree,
         ).to(device)
 
         # Summary of different parameter types: gate, local_experts
@@ -100,8 +103,8 @@ torch.manual_seed(0)
 x = torch.tensor(torch.randn([batch_size, num_tokens, model_dim], dtype=torch.float32, device='cpu').detach().numpy(), dtype=torch.get_default_dtype(), requires_grad=True, device=device)
 y = torch.LongTensor(batch_size).random_(1).to(device)
 
-tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, device)
-dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, device = `%s`' % tuples)
+tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, a2a_ffn_overlap_degree, device)
+dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, a2a_ffn_overlap_degree = %s, device = `%s`' % tuples)
 
 average_time, num_steps = 0, 100
 

--- a/tutel/examples/helloworld_ddp.py
+++ b/tutel/examples/helloworld_ddp.py
@@ -32,6 +32,7 @@ parser.add_argument('--dtype', type=str, default='float32')
 parser.add_argument('--fp32_gate', default=False, action='store_true')
 parser.add_argument('--top', type=int, default=2)
 parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
+parser.add_argument('--num_steps', type=int, default=100)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -106,7 +107,7 @@ y = torch.LongTensor(batch_size).random_(1).to(device)
 tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, a2a_ffn_overlap_degree, device)
 dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, a2a_ffn_overlap_degree = %s, device = `%s`' % tuples)
 
-average_time, num_steps = 0, 100
+average_time, num_steps = 0, args.num_steps
 
 for i in range(num_steps):
 

--- a/tutel/examples/helloworld_deepspeed.py
+++ b/tutel/examples/helloworld_deepspeed.py
@@ -28,6 +28,7 @@ parser.add_argument('--dtype', type=str, default='float32')
 parser.add_argument('--fp32_gate', default=False, action='store_true')
 parser.add_argument('--top', type=int, default=2)
 parser.add_argument('--use_tutel', default=False, action='store_true')
+parser.add_argument('--num_steps', type=int, default=100)
 args = parser.parse_args()
 
 try:
@@ -124,7 +125,7 @@ y = torch.LongTensor(batch_size).random_(1).to(device)
 tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, top_value, device)
 dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, topK = %s, device = `%s`' % tuples)
 
-average_time, num_steps = 0, 100
+average_time, num_steps = 0, args.num_steps
 
 params_for_all_reduce = [p for p in model.parameters() if not hasattr(p, 'skip_allreduce') and getattr(p, 'requires_grad', False) and p.grad is not None]
 

--- a/tutel/examples/helloworld_megatron.py
+++ b/tutel/examples/helloworld_megatron.py
@@ -28,6 +28,7 @@ parser.add_argument('--hidden_size', type=int, default=2048)
 parser.add_argument('--num_local_experts', type=int, default=2)
 parser.add_argument('--dtype', type=str, default='float32')
 parser.add_argument('--l_aux_wt', type=float, default=0.0)
+parser.add_argument('--num_steps', type=int, default=100)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -87,7 +88,7 @@ y = torch.LongTensor(batch_size).random_(1).to(device)
 tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, device)
 dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, gate = megatron, device = `%s`' % tuples)
 
-average_time, num_steps = 0, 100
+average_time, num_steps = 0, args.num_steps
 
 params_for_all_reduce = [p for p in model.parameters() if not hasattr(p, 'skip_allreduce') and getattr(p, 'requires_grad', False) and p.grad is not None]
 

--- a/tutel/examples/helloworld_megatron.py
+++ b/tutel/examples/helloworld_megatron.py
@@ -28,6 +28,7 @@ parser.add_argument('--hidden_size', type=int, default=2048)
 parser.add_argument('--num_local_experts', type=int, default=2)
 parser.add_argument('--dtype', type=str, default='float32')
 parser.add_argument('--l_aux_wt', type=float, default=0.0)
+parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -39,6 +40,7 @@ num_tokens = args.num_tokens
 model_dim = args.model_dim
 hidden_size = args.hidden_size
 num_local_experts = args.num_local_experts
+a2a_ffn_overlap_degree = args.a2a_ffn_overlap_degree
 device = parallel_env.local_device
 
 if args.dtype == 'float32':
@@ -63,6 +65,7 @@ class ExampleModel(torch.nn.Module):
             model_dim = model_dim,
             scan_expert_func = lambda name, param: setattr(param, 'skip_allreduce', True),
             seeds = (1, dist_rank + 1, 1),
+            a2a_ffn_overlap_degree = a2a_ffn_overlap_degree,
         ).to(device)
 
         # Summary of different parameter types: gate, local_experts
@@ -84,8 +87,8 @@ torch.manual_seed(0)
 x = torch.tensor(torch.randn([batch_size, num_tokens, model_dim], dtype=torch.float32, device='cpu').detach().numpy(), dtype=torch.get_default_dtype(), requires_grad=True, device=device)
 y = torch.LongTensor(batch_size).random_(1).to(device)
 
-tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, device)
-dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, gate = megatron, device = `%s`' % tuples)
+tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, a2a_ffn_overlap_degree, device)
+dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, gate = megatron, a2a_ffn_overlap_degree = %s, device = `%s`' % tuples)
 
 average_time, num_steps = 0, 100
 

--- a/tutel/examples/helloworld_megatron.py
+++ b/tutel/examples/helloworld_megatron.py
@@ -28,7 +28,6 @@ parser.add_argument('--hidden_size', type=int, default=2048)
 parser.add_argument('--num_local_experts', type=int, default=2)
 parser.add_argument('--dtype', type=str, default='float32')
 parser.add_argument('--l_aux_wt', type=float, default=0.0)
-parser.add_argument('--a2a_ffn_overlap_degree', type=int, default=1)
 args = parser.parse_args()
 
 parallel_env = system_init.init_data_model_parallel()
@@ -40,7 +39,6 @@ num_tokens = args.num_tokens
 model_dim = args.model_dim
 hidden_size = args.hidden_size
 num_local_experts = args.num_local_experts
-a2a_ffn_overlap_degree = args.a2a_ffn_overlap_degree
 device = parallel_env.local_device
 
 if args.dtype == 'float32':
@@ -65,7 +63,6 @@ class ExampleModel(torch.nn.Module):
             model_dim = model_dim,
             scan_expert_func = lambda name, param: setattr(param, 'skip_allreduce', True),
             seeds = (1, dist_rank + 1, 1),
-            a2a_ffn_overlap_degree = a2a_ffn_overlap_degree,
         ).to(device)
 
         # Summary of different parameter types: gate, local_experts
@@ -87,8 +84,8 @@ torch.manual_seed(0)
 x = torch.tensor(torch.randn([batch_size, num_tokens, model_dim], dtype=torch.float32, device='cpu').detach().numpy(), dtype=torch.get_default_dtype(), requires_grad=True, device=device)
 y = torch.LongTensor(batch_size).random_(1).to(device)
 
-tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, a2a_ffn_overlap_degree, device)
-dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, gate = megatron, a2a_ffn_overlap_degree = %s, device = `%s`' % tuples)
+tuples = (dist_world_size, args.dtype, model_dim, hidden_size, batch_size * num_tokens, num_local_experts, device)
+dist_print('[Benchmark] world_size = %s, dtype = %s, model_dim = %s, hidden_size = %s, samples = %s, num_local_experts = %s, gate = megatron, device = `%s`' % tuples)
 
 average_time, num_steps = 0, 100
 

--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -141,7 +141,6 @@ class TopKGate(torch.nn.Module):
 
         split_dim = 2
 
-        print(dispatched_input.shape)
         if self.a2a_ffn_overlap_degree == 1 or \
            dispatched_input.shape[split_dim] % self.a2a_ffn_overlap_degree:
             dispatched_input = AllToAll.apply(group, dispatched_input)

--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -46,7 +46,7 @@ class TopKGate(torch.nn.Module):
         self,
         model_dim,
         num_global_experts,
-        a2a_ffn_overlap_degree,
+        a2a_ffn_overlap_degree=1,
         capacity_factor=1.0,
         top_k=2,
         batch_prioritized_routing=False,
@@ -140,7 +140,10 @@ class TopKGate(torch.nn.Module):
         dispatched_input = dispatched_input.reshape(world_size, -1, capacity, M)
 
 
-        if self.a2a_ffn_overlap_degree == 1:
+        if self.a2a_ffn_overlap_degree == -1:
+            expert_output = expert_fn(dispatched_input)
+            expert_output = expert_output.to(input.dtype)
+        elif self.a2a_ffn_overlap_degree == 1:
             dispatched_input = AllToAll.apply(group, dispatched_input)
 
             expert_output = expert_fn(dispatched_input)


### PR DESCRIPTION
This is a PoC to overlap computation and communication of A2A-FFN-A2A phase in MoE layer.

To achieve this, data used in A2A-FFN-A2A phase is split into multiple chunks along batch size dimension. As a result, each chunk can be processed independently in both forward and backward pass.