### PR TITLE
Fix Bug - Fix various bugs in all-to-all FFN overlapping

### DIFF
--- a/tests/test_tutel.py
+++ b/tests/test_tutel.py
@@ -134,16 +134,16 @@ class TutelTestCase(unittest.TestCase):
     def test_a2a_ffn_overlap(self):
         """Test whether AllToAll-FFN overlapping works properly. Note that too small batch size might cause precision issue."""
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1, num_steps=10),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2, num_steps=10)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=-2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1, num_steps=10),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2, num_steps=10)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=1, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
             )
 
         self.assertEqual(
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=1, num_steps=10),
-            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=8, a2a_ffn_overlap_degree=2, num_steps=10)
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=1),
+            self.tutelCaller.run(nproc_per_node=2, helloworld_file='helloworld', top=2, dtype='float64', num_local_experts=2, show_step_time=False, batch_size=1, a2a_ffn_overlap_degree=2)
             )

--- a/tutel/custom/custom_kernel.cpp
+++ b/tutel/custom/custom_kernel.cpp
@@ -286,7 +286,6 @@ template<typename dtype> static void invoke_cpu(const std::vector<torch::Tensor>
 static ncclComm_t g_nccl_comm;
 static std::vector<at::cuda::CUDAEvent> g_cuda_events;
 static int g_num_split = 0;
-static int g_num_slices_per_split = 0;
 static int g_world_size = 0;
 
 static size_t get_nccl_unique_id_size() {
@@ -306,8 +305,7 @@ static void init_nccl(
     const torch::Tensor &nccl_unique_id_tensor,
     int world_size,
     int world_rank,
-    int num_split,
-    int num_slices_per_split) {
+    int num_split) {
   ncclUniqueId nccl_unique_id;
 
   CHECK_CPU(nccl_unique_id_tensor);
@@ -319,7 +317,6 @@ static void init_nccl(
 
   g_num_split = num_split;
   g_cuda_events.resize(num_split);
-  g_num_slices_per_split = num_slices_per_split;
   g_world_size = world_size;
 }
 
@@ -341,6 +338,7 @@ static torch::Tensor& current_stream_acquire(torch::Tensor &tensor, int idx) {
 static void nccl_all_to_all_scatter_async(
     const torch::Tensor &input,
     std::vector<torch::Tensor> &output_list,
+    int num_slices_per_split,
     bool is_backward) {
   CHECK_CUDA(input);
   CHECK_EQ(g_num_split, output_list.size());
@@ -348,9 +346,9 @@ static void nccl_all_to_all_scatter_async(
     CHECK_CUDA(output);
   }
 
-  CHECK_EQ(0, g_num_slices_per_split % g_world_size);
+  CHECK_EQ(0, num_slices_per_split % g_world_size);
   size_t length = input.nbytes();
-  size_t num_slices = g_num_slices_per_split * g_num_split;
+  size_t num_slices = num_slices_per_split * g_num_split;
   CHECK_EQ(0, length % num_slices);
   size_t slice_size = length / num_slices;
 
@@ -368,19 +366,19 @@ static void nccl_all_to_all_scatter_async(
     int calc_idx = is_backward ? g_num_split - 1 - i : i;
 
     CHECK_EQ(0, ncclGroupStart());
-    for (int j = 0; j < g_num_slices_per_split; j++) {
+    for (int j = 0; j < num_slices_per_split; j++) {
       CHECK_EQ(0, ncclSend(
           ((char*)input.data_ptr()) + (j * g_num_split + calc_idx) * slice_size,
           slice_size,
           ncclInt8,
-          g_world_size * j / g_num_slices_per_split,
+          g_world_size * j / num_slices_per_split,
           g_nccl_comm,
           get_nccl_stream().stream()));
       CHECK_EQ(0, ncclRecv(
           ((char*)output_list[calc_idx].data_ptr()) + j * slice_size,
           slice_size,
           ncclInt8,
-          g_world_size * j / g_num_slices_per_split,
+          g_world_size * j / num_slices_per_split,
           g_nccl_comm,
           get_nccl_stream().stream()));
     }
@@ -394,6 +392,7 @@ static void nccl_all_to_all_scatter_async(
 static void nccl_all_to_all_gather_async(
     const std::vector<torch::Tensor> &input_list,
     torch::Tensor &output,
+    int num_slices_per_split,
     bool is_backward) {
   CHECK_EQ(g_num_split, input_list.size());
   for (auto& input : input_list) {
@@ -401,9 +400,9 @@ static void nccl_all_to_all_gather_async(
   }
   CHECK_CUDA(output);
 
-  CHECK_EQ(0, g_num_slices_per_split % g_world_size);
+  CHECK_EQ(0, num_slices_per_split % g_world_size);
   size_t length = output.nbytes();
-  size_t num_slices = g_num_slices_per_split * g_num_split;
+  size_t num_slices = num_slices_per_split * g_num_split;
   CHECK_EQ(0, length % num_slices);
   size_t slice_size = length / num_slices;
 
@@ -421,19 +420,19 @@ static void nccl_all_to_all_gather_async(
     g_cuda_events[calc_idx].block(get_nccl_stream());
 
     CHECK_EQ(0, ncclGroupStart());
-    for (int j = 0; j < g_num_slices_per_split; j++) {
+    for (int j = 0; j < num_slices_per_split; j++) {
       CHECK_EQ(0, ncclSend(
           ((char*)input_list[calc_idx].data_ptr()) + j * slice_size,
           slice_size,
           ncclInt8,
-          g_world_size * j / g_num_slices_per_split,
+          g_world_size * j / num_slices_per_split,
           g_nccl_comm,
           get_nccl_stream().stream()));
       CHECK_EQ(0, ncclRecv(
           ((char*)output.data_ptr()) + (j * g_num_split + calc_idx) * slice_size,
           slice_size,
           ncclInt8,
-          g_world_size * j / g_num_slices_per_split,
+          g_world_size * j / num_slices_per_split,
           g_nccl_comm,
           get_nccl_stream().stream()));
     }

--- a/tutel/custom/custom_kernel.cpp
+++ b/tutel/custom/custom_kernel.cpp
@@ -349,6 +349,7 @@ static std::vector<torch::Tensor> nccl_all_to_all_scatter_async(
   size_t slice_size = length / num_slices;
 
   // Save original stream and switch to NCCL stream
+  // Output tensors must be allocated in NCCL stream context to prevent PyTorch Caching Allocator from recycling it
   const at::cuda::CUDAStream& original_stream = at::cuda::getCurrentCUDAStream();
   at::cuda::setCurrentCUDAStream(get_nccl_stream());
 
@@ -413,6 +414,7 @@ static torch::Tensor nccl_all_to_all_gather_async(
   CHECK_EQ(0, num_slices_per_split % g_world_size);
 
   // Save original stream and switch to NCCL stream
+  // Output tensor must be allocated in NCCL stream context to prevent PyTorch Caching Allocator from recycling it
   const at::cuda::CUDAStream& original_stream = at::cuda::getCurrentCUDAStream();
   at::cuda::setCurrentCUDAStream(get_nccl_stream());
 

--- a/tutel/impls/communicate.py
+++ b/tutel/impls/communicate.py
@@ -31,40 +31,32 @@ class AllToAllStatus:
     gather_tensor_shape = None
     scatter_tensor_shape = None
     num_split = 0
-    world_size = 0
+    split_dim = 0
 
     @staticmethod
     def init(group: dist.ProcessGroup, num_split: int, split_dim: int, gather_tensor_ref: Tensor) -> None:
-        AllToAllStatus.world_size = get_world_size(group)
-        if AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        world_size = get_world_size(group)
+        if world_size <= 1:
             return
 
-        # Make sure addresses of tensors allocated are not in use
-        torch.cuda.synchronize()
+        AllToAllStatus.num_split = num_split
+        AllToAllStatus.split_dim = split_dim
 
         # Initialize NCCL
-        world_rank = get_world_rank(group)
-        nccl_unique_id_size = tutel_custom_kernel.get_nccl_unique_id_size()
-        nccl_unique_id = torch.zeros([nccl_unique_id_size], dtype=torch.int8).cpu()
-        if world_rank == 0:
-            tutel_custom_kernel.get_nccl_unique_id(nccl_unique_id)
-        nccl_unique_id = nccl_unique_id.to(gather_tensor_ref.device)
-        dist.broadcast(nccl_unique_id, 0, group)
-        AllToAllStatus.num_split = num_split
-        tutel_custom_kernel.init_nccl(
-            nccl_unique_id.cpu(),
-            AllToAllStatus.world_size,
-            world_rank,
-            AllToAllStatus.num_split,
-            gather_tensor_ref.shape[:split_dim].numel())
-
-        AllToAllStatus.gather_tensor_shape = list(gather_tensor_ref.shape)
-        AllToAllStatus.scatter_tensor_shape = [
-            x if i != split_dim else x // AllToAllStatus.num_split
-            for i, x in enumerate(AllToAllStatus.gather_tensor_shape)
-        ]
-
-        AllToAllStatus.initialized = True
+        if not AllToAllStatus.initialized:
+            world_rank = get_world_rank(group)
+            nccl_unique_id_size = tutel_custom_kernel.get_nccl_unique_id_size()
+            nccl_unique_id = torch.zeros([nccl_unique_id_size], dtype=torch.int8).cpu()
+            if world_rank == 0:
+                tutel_custom_kernel.get_nccl_unique_id(nccl_unique_id)
+            nccl_unique_id = nccl_unique_id.to(gather_tensor_ref.device)
+            dist.broadcast(nccl_unique_id, 0, group)
+            tutel_custom_kernel.init_nccl(
+                nccl_unique_id.cpu(),
+                world_size,
+                world_rank,
+                AllToAllStatus.num_split)
+            AllToAllStatus.initialized = True
 
 class AllToAll(torch.autograd.Function):
     @staticmethod
@@ -85,7 +77,7 @@ class AllToAll(torch.autograd.Function):
 class CurrentStreamRelease(torch.autograd.Function):
     @staticmethod
     def forward(ctx: Any, input: Tensor, idx: int) -> Tensor:
-        if not AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        if not AllToAllStatus.initialized:
             return input
         ctx.idx = idx
         input = input.contiguous()
@@ -93,21 +85,21 @@ class CurrentStreamRelease(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx: Any, grad_output: Tensor) -> Tensor:
-        if not AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        if not AllToAllStatus.initialized:
             return (grad_output, None)
         return (tutel_custom_kernel.current_stream_acquire(grad_output, ctx.idx), None)
 
 class CurrentStreamAcquire(torch.autograd.Function):
     @staticmethod
     def forward(ctx: Any, input: Tensor, idx: int) -> Tensor:
-        if not AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        if not AllToAllStatus.initialized:
             return input
         ctx.idx = idx
         return tutel_custom_kernel.current_stream_acquire(input, idx)
 
     @staticmethod
     def backward(ctx: Any, grad_output: Tensor) -> Tensor:
-        if not AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        if not AllToAllStatus.initialized:
             return (grad_output, None)
         grad_output = grad_output.contiguous()
         return (tutel_custom_kernel.current_stream_release(grad_output, ctx.idx), None)
@@ -115,41 +107,53 @@ class CurrentStreamAcquire(torch.autograd.Function):
 class AllToAllScatterAsync(torch.autograd.Function):
     @staticmethod
     def forward(ctx: Any, input: Tensor) -> Tuple[Tensor]:
-        if not AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        if not AllToAllStatus.initialized:
             return (input,)
+        ctx.input_shape = input.shape
+        output_shape = torch.Size([
+            x if i != AllToAllStatus.split_dim else x // AllToAllStatus.num_split
+            for i, x in enumerate(ctx.input_shape)
+        ])
         output = [
-            torch.empty(AllToAllStatus.scatter_tensor_shape, device=input.device).contiguous()
+            torch.empty(output_shape, device=input.device).contiguous()
             for _ in range(AllToAllStatus.num_split)
         ]
-        tutel_custom_kernel.nccl_all_to_all_scatter_async(input, output, False)
+        ctx.num_slices_per_split = ctx.input_shape[:AllToAllStatus.split_dim].numel()
+        tutel_custom_kernel.nccl_all_to_all_scatter_async(input, output, ctx.num_slices_per_split, False)
         return tuple(output)
 
     @staticmethod
     def backward(ctx: Any, *grad_output) -> Tensor:
-        if not AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        if not AllToAllStatus.initialized:
             return grad_output[0]
-        grad_input = torch.empty(AllToAllStatus.gather_tensor_shape, device=grad_output[0].device).contiguous()
-        tutel_custom_kernel.nccl_all_to_all_gather_async(grad_output, grad_input, True)
+        grad_input = torch.empty(ctx.input_shape, device=grad_output[0].device).contiguous()
+        tutel_custom_kernel.nccl_all_to_all_gather_async(grad_output, grad_input, ctx.num_slices_per_split, True)
         return grad_input
 
 class AllToAllGatherAsync(torch.autograd.Function):
     @staticmethod
     def forward(ctx: Any, *input) -> Tensor:
-        if not AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        if not AllToAllStatus.initialized:
             return input[0]
-        output = torch.empty(AllToAllStatus.gather_tensor_shape, device=input[0].device).contiguous()
-        tutel_custom_kernel.nccl_all_to_all_gather_async(input, output, False)
+        ctx.input_shape = input[0].shape
+        output_shape = torch.Size([
+            x if i != AllToAllStatus.split_dim else x * AllToAllStatus.num_split
+            for i, x in enumerate(ctx.input_shape)
+        ])
+        output = torch.empty(output_shape, device=input[0].device).contiguous()
+        ctx.num_slices_per_split = ctx.input_shape[:AllToAllStatus.split_dim].numel()
+        tutel_custom_kernel.nccl_all_to_all_gather_async(input, output, ctx.num_slices_per_split, False)
         return output
 
     @staticmethod
     def backward(ctx: Any, grad_output: Tensor) -> Tuple[Tensor]:
-        if not AllToAllStatus.initialized or AllToAllStatus.world_size <= 1:
+        if not AllToAllStatus.initialized:
             return (grad_output,)
         grad_input = [
-            torch.empty(AllToAllStatus.scatter_tensor_shape, device=grad_output.device).contiguous()
+            torch.empty(ctx.input_shape, device=grad_output.device).contiguous()
             for _ in range(AllToAllStatus.num_split)
         ]
-        tutel_custom_kernel.nccl_all_to_all_scatter_async(grad_output, grad_input, True)
+        tutel_custom_kernel.nccl_all_to_all_scatter_async(grad_output, grad_input, ctx.num_slices_per_split, True)
         return tuple(grad_input)
 
 


### PR DESCRIPTION
This commit fixes the following bugs in all-to-all FFN overlapping:
1) All-to-all and FFN overlapping assumes there is only one possible shape for input once initialized, and will crash if input shape changes.
2) All-to-all output buffers are allocated on computation stream, and this might cause PyTorch Caching Allocator to re-use buffers used by previous computation, which would lead to data race when all-to-all and computation are overlapped.