### PR TITLE
Fix ROCm hipify issue for backward compatibility

### DIFF
--- a/tutel/custom/custom_kernel.cpp
+++ b/tutel/custom/custom_kernel.cpp
@@ -360,10 +360,10 @@ extern "C" __global__ void memStrideCopyKernel(
     CHECK_NE(-1, mem_stride_copy_char_fd);
     CHECK_NE(-1, mem_stride_copy_uint4_fd);
     CUfunction hfunc = jit::jit_activate(mem_stride_copy_uint4_fd, g_local_rank);
-#if !defined(HIP_VERSION) || HIP_VERSION > 402
+#if !defined(__HIP_PLATFORM_HCC__)
     CHECK_EQ(0, cuOccupancyMaxPotentialBlockSize(&mem_stride_copy_gridsize, &mem_stride_copy_blocksize, hfunc, 0, 0, 0));
 #else
-    CHECK_EQ(0, hipOccupancyMaxPotentialBlockSize(&mem_stride_copy_gridsize, &mem_stride_copy_blocksize, hfunc, 0, 0U));
+    CHECK_EQ(0, hipModuleOccupancyMaxPotentialBlockSize(&mem_stride_copy_gridsize, &mem_stride_copy_blocksize, hfunc, 0, 0));
 #endif
   }
 }


### PR DESCRIPTION
Current ROCm 5.0 versions have issue to hipify `cuOccupancyMaxPotentialBlockSize`, force change to `hipModuleOccupancyMaxPotentialBlockSize` manually.

Reference:
* [cuda_to_hip_mappings in PyTorch](https://github.com/pytorch/pytorch/blob/v1.11.0/torch/utils/hipify/cuda_to_hip_mappings.py#L2922-L2923)
* Latest fix in hipify https://github.com/ROCm-Developer-Tools/HIPIFY/pull/482