### PR TITLE
add reset_parameters fn; updt .to() fn; enable device and dtype pass thru

### DIFF
--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -101,10 +101,10 @@ class FusedExpertsNetwork(torch.nn.Module):
 
     def to(self, *args, **kwargs):
         self = super().to(*args, **kwargs)
-        self.batched_fc1_w = self.batched_fc1_w.to(*args, **kwargs)
-        self.batched_fc2_w = self.batched_fc2_w.to(*args, **kwargs)
-        self.batched_fc1_bias = self.batched_fc1_bias.to(*args, **kwargs)
-        self.batched_fc2_bias = self.batched_fc2_bias.to(*args, **kwargs)
+        self.fc1_weight = self.fc1_weight.to(*args, **kwargs)
+        self.fc2_weight = self.fc2_weight.to(*args, **kwargs)
+        self.fc1_bias = self.fc1_bias.to(*args, **kwargs)
+        self.fc2_bias = self.fc2_bias.to(*args, **kwargs)
         return self
 
 ExpertModule = FusedExpertsNetwork 

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -99,5 +99,12 @@ class FusedExpertsNetwork(torch.nn.Module):
         y = torch.add(torch.matmul(y, batched_fc2_w), batched_fc2_bias)
         return y
 
+    def to(self, *args, **kwargs):
+        self = super().to(*args, **kwargs)
+        self.batched_fc1_w = self.batched_fc1_w.to(*args, **kwargs)
+        self.batched_fc2_w = self.batched_fc2_w.to(*args, **kwargs)
+        self.batched_fc1_bias = self.batched_fc1_bias.to(*args, **kwargs)
+        self.batched_fc2_bias = self.batched_fc2_bias.to(*args, **kwargs)
+        return self
 
 ExpertModule = FusedExpertsNetwork 

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -52,7 +52,6 @@ class FusedExpertsNetwork(torch.nn.Module):
 
     def reset_parameters(self) -> None:
         # imitate reset_parameters from torch.nn.Linear
-
         mode = 'fan_in'
         a = math.sqrt(5)
 

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -101,10 +101,10 @@ class FusedExpertsNetwork(torch.nn.Module):
 
     def to(self, *args, **kwargs):
         self = super().to(*args, **kwargs)
-        self.fc1_weight = self.fc1_weight.to(*args, **kwargs)
-        self.fc2_weight = self.fc2_weight.to(*args, **kwargs)
-        self.fc1_bias = self.fc1_bias.to(*args, **kwargs)
-        self.fc2_bias = self.fc2_bias.to(*args, **kwargs)
+        self.batched_fc1_w = self.batched_fc1_w.to(*args, **kwargs)
+        self.batched_fc2_w = self.batched_fc2_w.to(*args, **kwargs)
+        self.batched_fc1_bias = self.batched_fc1_bias.to(*args, **kwargs)
+        self.batched_fc2_bias = self.batched_fc2_bias.to(*args, **kwargs)
         return self
 
 ExpertModule = FusedExpertsNetwork 

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -2,7 +2,6 @@
 # Licensed under the MIT license.
 
 import math
-import warnings
 import torch
 from torch.nn import functional as F
 from torch.nn import init

--- a/tutel/gates/cosine_top.py
+++ b/tutel/gates/cosine_top.py
@@ -5,12 +5,12 @@ import torch
 import torch.nn.functional as F
 
 class CosineTopKGate(torch.nn.Module):
-    def __init__(self, model_dim, num_global_experts, k=1, fp32_gate=False, device=None, proj_dim=256, init_t=0.5, **options):
+    def __init__(self, model_dim, num_global_experts, k=1, fp32_gate=False, device=None, dtype=None, proj_dim=256, init_t=0.5, **options):
         super(CosineTopKGate, self).__init__()
         self.top_k = min(num_global_experts, int(k))
         self.fp32_gate = fp32_gate
         self.temperature = torch.nn.Parameter(torch.log(torch.full([1], 1.0 / init_t)), requires_grad=True)
-        self.cosine_projector = torch.nn.Linear(model_dim, proj_dim, device=device)
+        self.cosine_projector = torch.nn.Linear(model_dim, proj_dim, device=device, dtype=dtype)
         self.sim_matrix = torch.nn.Parameter(torch.randn(size=(proj_dim, num_global_experts)), requires_grad=True)
         self.clamp_max = torch.log(torch.tensor(1. / 0.01)).item()
         torch.nn.init.normal_(self.sim_matrix, 0, 0.01)

--- a/tutel/gates/cosine_top.py
+++ b/tutel/gates/cosine_top.py
@@ -5,12 +5,12 @@ import torch
 import torch.nn.functional as F
 
 class CosineTopKGate(torch.nn.Module):
-    def __init__(self, model_dim, num_global_experts, k=1, fp32_gate=False, proj_dim=256, init_t=0.5, **options):
+    def __init__(self, model_dim, num_global_experts, k=1, fp32_gate=False, device=None, proj_dim=256, init_t=0.5, **options):
         super(CosineTopKGate, self).__init__()
         self.top_k = min(num_global_experts, int(k))
         self.fp32_gate = fp32_gate
         self.temperature = torch.nn.Parameter(torch.log(torch.full([1], 1.0 / init_t)), requires_grad=True)
-        self.cosine_projector = torch.nn.Linear(model_dim, proj_dim)
+        self.cosine_projector = torch.nn.Linear(model_dim, proj_dim, device=device)
         self.sim_matrix = torch.nn.Parameter(torch.randn(size=(proj_dim, num_global_experts)), requires_grad=True)
         self.clamp_max = torch.log(torch.tensor(1. / 0.01)).item()
         torch.nn.init.normal_(self.sim_matrix, 0, 0.01)

--- a/tutel/gates/top.py
+++ b/tutel/gates/top.py
@@ -19,7 +19,6 @@ class LinearTopKGate(torch.nn.Module):
             x = x.float()
         with torch.autocast(device_type=x.device.type, enabled=not self.fp32_gate):
             out = self.wg(x)
-            print(out.dtype)
             return out
 
 

--- a/tutel/gates/top.py
+++ b/tutel/gates/top.py
@@ -4,12 +4,12 @@
 import torch
 
 class LinearTopKGate(torch.nn.Module):
-    def __init__(self, model_dim, num_global_experts, k=1, fp32_gate=False, device=None, **options):
+    def __init__(self, model_dim, num_global_experts, k=1, fp32_gate=False, device=None, dtype=None, **options):
         super().__init__()
         try:
-            self.wg = torch.nn.Linear(model_dim, num_global_experts, bias=False, device=device, dtype=torch.float32 if fp32_gate else None)
+            self.wg = torch.nn.Linear(model_dim, num_global_experts, bias=False, device=device, dtype=torch.float32 if fp32_gate else dtype)
         except:
-            self.wg = torch.nn.Linear(model_dim, num_global_experts, bias=False, device=device)
+            self.wg = torch.nn.Linear(model_dim, num_global_experts, bias=False, device=device, dtype=dtype)
         self.top_k = min(num_global_experts, int(k))
         self.fp32_gate = fp32_gate
 

--- a/tutel/gates/top.py
+++ b/tutel/gates/top.py
@@ -4,12 +4,12 @@
 import torch
 
 class LinearTopKGate(torch.nn.Module):
-    def __init__(self, model_dim, num_global_experts, k=1, fp32_gate=False, **options):
+    def __init__(self, model_dim, num_global_experts, k=1, fp32_gate=False, device=None, **options):
         super().__init__()
         try:
-            self.wg = torch.nn.Linear(model_dim, num_global_experts, bias=False, dtype=torch.float32 if fp32_gate else None)
+            self.wg = torch.nn.Linear(model_dim, num_global_experts, bias=False, device=device, dtype=torch.float32 if fp32_gate else None)
         except:
-            self.wg = torch.nn.Linear(model_dim, num_global_experts, bias=False)
+            self.wg = torch.nn.Linear(model_dim, num_global_experts, bias=False, device=device)
         self.top_k = min(num_global_experts, int(k))
         self.fp32_gate = fp32_gate
 

--- a/tutel/impls/jit_compiler.py
+++ b/tutel/impls/jit_compiler.py
@@ -3,20 +3,23 @@
 
 import torch
 import os, tempfile
+import logging
 
-try:
-    import tutel_custom_kernel
-except:
-    raise Exception("Cannot import JIT optimized kernels. Did you forget to install Custom Kernel Extension?")
 
 try:
     from torch.utils.cpp_extension import IS_HIP_EXTENSION, CUDA_HOME, ROCM_HOME
 except:
     IS_HIP_EXTENSION = False
 
-if hasattr(tutel_custom_kernel, 'update_sdk_home'):
-    SDK_HOME = CUDA_HOME if not IS_HIP_EXTENSION else ROCM_HOME
-    tutel_custom_kernel.update_sdk_home(torch.tensor([ord(x) for x in SDK_HOME] + [0], dtype=torch.int8, device='cpu'))
+try:
+    import tutel_custom_kernel
+
+    if hasattr(tutel_custom_kernel, 'update_sdk_home'):
+        SDK_HOME = CUDA_HOME if not IS_HIP_EXTENSION else ROCM_HOME
+        tutel_custom_kernel.update_sdk_home(torch.tensor([ord(x) for x in SDK_HOME] + [0], dtype=torch.int8, device='cpu'))
+except:
+    logging.warning("Cannot import JIT optimized kernels. CUDA extension will be disabled.")
+
 
 class JitCompiler:
     @staticmethod

--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -10,7 +10,6 @@ import time
 import logging 
 import collections
 import importlib
-import warnings
 
 import torch
 from torch import Tensor

--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -79,6 +79,8 @@ class MOELayer(torch.nn.Module):
         is_gshard_loss=True,
         parallel_type='auto',
         use_2dh=False,
+        device=None,
+        dtype=None,
         **kwargs
     ):
         super().__init__()
@@ -156,7 +158,7 @@ class MOELayer(torch.nn.Module):
 
             self.experts = fused_experts.ExpertModule(**experts)
 
-        self.experts.update(self)
+        self.experts.update(self, device=device, dtype=dtype)
 
         if scan_expert_func is not None:
             for n, p in self.experts.named_parameters():
@@ -260,7 +262,6 @@ class MOELayer(torch.nn.Module):
                 alignment = self.sharded_count * a2a_ffn_overlap_degree,
                 inequivalent_tokens = inequivalent_tokens,
             )
-
 
         if x.is_cuda:
             with torch.cuda.amp.autocast(enabled=False):

--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -270,8 +270,6 @@ class MOELayer(torch.nn.Module):
 
         y = fast_encode(x.to(logits_dtype), crit, self.is_postscore).to(x.dtype)
 
-        print(f'{original_dtype=}, {x.dtype=}, {logits_dtype=}, {y.dtype=}')
-
         if self.force_data_parallel:
             y = self.expert_local(y, original_shape[-reserve_dims:])
         else:

--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -233,10 +233,13 @@ class MOELayer(torch.nn.Module):
             if input.device.type == 'cuda':
                 dtype = torch.get_autocast_gpu_dtype()
             elif input.device.type == 'cpu':
-                warnings.warn(f'MoE input is a cpu tensor.')
                 dtype = torch.get_autocast_cpu_dtype()
+            elif input.device.type == 'xpu':
+                dtype = torch.xpu.get_autocast_xpu_dtype()  # type: ignore[attr-defined]
+            elif input.device.type == 'hpu':
+                dtype = torch.hpu.get_autocast_hpu_dtype()  # type: ignore[attr-defined]
             else:
-                raise NotImplementedError(f'MoE not implemented for device={input.device.type}')
+                raise RuntimeError('User specified autocast device_type must be \'cuda\' or \'cpu\'')
             input = input.to(dtype=dtype)
 
         original_shape, original_dtype  = input.shape, input.dtype

--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -96,7 +96,7 @@ class MOELayer(torch.nn.Module):
         self.skip_moe = (int(os.environ.get('SKIP_MOE', '0')) != 0)
 
         self.num_local_experts = experts.pop('count_per_node', 1)
-        self._num_global_experts = torch.tensor(MOELayer.global_expert_count(self.num_local_experts, self.group))
+        self.register_buffer('_num_global_experts', torch.tensor(MOELayer.global_expert_count(self.num_local_experts, self.group)))
 
         self.world_size = C.get_world_size(self.group)
         if self.num_global_experts < self.world_size:


### PR DESCRIPTION
This PR
1. adds `reset_parameters` fn to `FusedExpertNetwork`.
1. removes `to(*args)` fn from `FusedExpertsNetwork`
    - The layer imlp does not have `self.fc1_weight`, `self.fc2_weight`, `self.fc1_bias`, or `self.fc2_bias`.
    - This `to(*args)` fn is a bug.
    - At [one point](https://github.com/microsoft/tutel/blob/v0.1.5/tutel/impls/moe_layer.py#L341), this would have been correct, but it is no longer correct.
1. Also propagating `device=device` and `dtype=dtype` to parameter init