### PR TITLE
fix a few casts

### DIFF
--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -98,12 +98,5 @@ class FusedExpertsNetwork(torch.nn.Module):
         y = torch.add(torch.matmul(y, batched_fc2_w), batched_fc2_bias)
         return y
 
-    def to(self, *args, **kwargs):
-        self = super().to(*args, **kwargs)
-        self.fc1_weight = self.fc1_weight.to(*args, **kwargs)
-        self.fc2_weight = self.fc2_weight.to(*args, **kwargs)
-        self.fc1_bias = self.fc1_bias.to(*args, **kwargs)
-        self.fc2_bias = self.fc2_bias.to(*args, **kwargs)
-        return self
 
 ExpertModule = FusedExpertsNetwork 

--- a/tutel/gates/top.py
+++ b/tutel/gates/top.py
@@ -18,11 +18,8 @@ class LinearTopKGate(torch.nn.Module):
                 raise Exception('Unrecognized argument provided to Gating module: %s' % opt)
 
     def forward(self, x):
-        if self.fp32_gate:
-            x = x.float()
-            wg = self.wg.float()
-        else:
-            wg = self.wg
-        return wg(x)
+        wg = self.wg.float() if self.fp32_gate else self.wg
+        return wg(x.to(dtype=wg.weight.dtype))
+
 
 Gate = LinearTopKGate


### PR DESCRIPTION
This PR

1. removes `to(*args)` fn from `FusedExpertsNetwork`
    - The layer imlp does not have `self.fc1_weight`, `self.fc2_weight`, `self.fc1_bias`, or `self.fc2_bias`.
    - This `to(*args)` fn is a bug.
    - At [one point](https://github.com/microsoft/tutel/blob/v0.1.5/tutel/impls/moe_layer.py#L341), this would have been correct, but it is no longer correct.
1. autocasts x in expert fn
    - `p = list[experts.parameters()][0]` will have dtype fp32 if using generic torch autocast; adding autocast to x if autocast enabled.
1. better cast x in gate