### PR TITLE
Enable running without bias and update ffn instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ print(y)
         type             : available built-in experts implementation, e.g: ffn
         hidden_size_per_expert : the hidden size between two linear layers for each expert (used for type == 'ffn' only)
         activation_fn    : the custom-defined activation function between two linear layers (used for type == 'ffn' only)
+        bias             : If set to False, the expert bias parameters (`batched_fc1_bias`` and `batched_fc2_bias``) are disabled. Default: True
 ```
 
 ### Reference

--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ print(y)
         type             : available built-in experts implementation, e.g: ffn
         hidden_size_per_expert : the hidden size between two linear layers for each expert (used for type == 'ffn' only)
         activation_fn    : the custom-defined activation function between two linear layers (used for type == 'ffn' only)
-        bias             : If set to False, the expert bias parameters (`batched_fc1_bias`` and `batched_fc2_bias``) are disabled. Default: True
+        has_fc1_bias     : If set to False, the expert bias parameters `batched_fc1_bias` is disabled. Default: True
+        has_fc2_bias     : If set to False, the expert bias parameters `batched_fc2_bias` is disabled. Default: True
 ```
 
 ### Reference

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -47,8 +47,9 @@ class FusedExpertsNetwork(torch.nn.Module):
                     self.batched_fc2_bias[i] = fc2.bias[:self.batched_fc2_bias.size(-1)]
 
     def extra_repr(self):
-        return 'model_dim=%d, hidden_size=%d, output_dim=%d, local_experts=%d. has_bias=%s.' % (
-            self.batched_fc1_w.size(2), self.batched_fc1_w.size(1), self.batched_fc2_w.size(2), self.batched_fc1_w.size(0), self.batched_fc1_bias is not None
+        return 'model_dim=%d, hidden_size=%d, output_dim=%d, local_experts=%d. has_fc1_bias=%s, has_fc2_bias=%s.' % (
+            self.batched_fc1_w.size(2), self.batched_fc1_w.size(1), self.batched_fc2_w.size(2), self.batched_fc1_w.size(0),
+            self.batched_fc1_bias is not None, self.batched_fc2_bias is not None
         )
 
     def forward(self, x, ctx):

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -29,7 +29,7 @@ class FusedExpertsNetwork(torch.nn.Module):
              self.batched_fc1_bias = torch.nn.Parameter(torch.empty(local_experts, self.hidden_size))
         else:
              self.register_parameter('batched_fc1_bias', None)
-        if has_fc2_bias: 
+        if has_fc2_bias:
             self.batched_fc2_bias = torch.nn.Parameter(torch.empty(local_experts, (self.output_dim + sharded_count - 1) // sharded_count))
         else:
             self.register_parameter('batched_fc2_bias', None)

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -37,10 +37,14 @@ class FusedExpertsNetwork(torch.nn.Module):
     def reset_parameters(self):
         with torch.no_grad():
             for i in range(self.batched_fc1_w.size(0)):
-                fc1 = torch.nn.Linear(self.model_dim, self.hidden_size)
-                fc2 = torch.nn.Linear(self.hidden_size, self.output_dim)
-                self.batched_fc1_w[i], self.batched_fc2_bias[i] = fc1.weight, fc1.bias
-                self.batched_fc2_w[i], self.batched_fc2_bias[i] = fc2.weight.t(), fc2.bias[:self.batched_fc2_bias.size(-1)]
+                fc1 = torch.nn.Linear(self.model_dim, self.hidden_size, bias=self.batched_fc1_bias is not None)
+                fc2 = torch.nn.Linear(self.hidden_size, self.output_dim, bias=self.batched_fc2_bias is not None)
+                self.batched_fc1_w[i] = fc1.weight
+                if self.batched_fc1_bias is not None:
+                    self.batched_fc1_bias[i] = fc1.bias
+                self.batched_fc2_w[i] = fc2.weight.t()
+                if self.batched_fc2_bias is not None:
+                    self.batched_fc2_bias[i] = fc2.bias[:self.batched_fc2_bias.size(-1)]
 
     def extra_repr(self):
         return 'model_dim=%d, hidden_size=%d, output_dim=%d, local_experts=%d. has bias=%s.' % (

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -5,11 +5,16 @@ import torch
 from .. import net
 
 class FusedExpertsNetwork(torch.nn.Module):
-    def __init__(self, hidden_size_per_expert, activation_fn=None, activation_fn_with_self=None, output_dim=None):
+    def __init__(self, model_dim, hidden_size_per_expert, local_experts, sharded_count, activation_fn=None, activation_fn_with_self=None, output_dim=None, bias=True):
         super().__init__()
         self.skip_expert = (int(torch.os.environ.get('SKIP_EXPERT', '0')) != 0)
+        assert hidden_size_per_expert % sharded_count == 0, f"Can't evenly divide hidden_size_per_expert ({hidden_size_per_expert}) to {sharded_count} slices."
+        self.model_dim = model_dim
         self.hidden_size_per_expert = hidden_size_per_expert
-        self.output_dim = output_dim
+        self.local_experts = local_experts
+        self.sharded_count = sharded_count
+        self.hidden_size = hidden_size_per_expert // sharded_count
+        self.output_dim = output_dim or model_dim
 
         if activation_fn_with_self is not None:
             assert activation_fn is None, "Option `activation_fn_with_self` has been specified, please keep exactly one of them."
@@ -18,30 +23,24 @@ class FusedExpertsNetwork(torch.nn.Module):
             activation_fn = lambda x: F.relu(x)
         self.activation_fn = activation_fn
 
-    def update(self, ctx):
-        if ctx.sharded_count > 1:
-            assert self.hidden_size_per_expert % ctx.sharded_count == 0, f"Can't evenly divide hidden_size_per_expert ({self.hidden_size_per_expert}) to {ctx.sharded_count} slices."
+        self.batched_fc1_w = torch.nn.Parameter(torch.empty(local_experts, self.hidden_size, model_dim))
+        self.batched_fc2_w = torch.nn.Parameter(torch.empty(local_experts, self.hidden_size, self.output_dim))
+        if bias:
+            self.batched_fc1_bias = torch.nn.Parameter(torch.empty(local_experts, self.hidden_size))
+            self.batched_fc2_bias = torch.nn.Parameter(torch.empty(local_experts, (self.output_dim + sharded_count - 1) // sharded_count))
+        else:
+            self.register_parameter('batched_fc1_bias', None)
+            self.register_parameter('batched_fc2_bias', None)
 
-        hidden_size = self.hidden_size_per_expert // ctx.sharded_count
-        model_dim = ctx.model_dim
-        local_experts = ctx.num_local_experts
-        self.output_dim = self.output_dim or model_dim
+        self.reset_parameters()
 
-        fc1_weight = torch.empty(1, local_experts, hidden_size, model_dim)
-        fc2_weight = torch.empty(1, local_experts, hidden_size, self.output_dim)
-        fc1_bias = torch.empty(1, local_experts, hidden_size)
-        fc2_bias = torch.empty(1, local_experts, (self.output_dim + ctx.sharded_count - 1) // ctx.sharded_count)
-
-        for i in range(local_experts):
-            fc1 = torch.nn.Linear(model_dim, hidden_size)
-            fc2 = torch.nn.Linear(hidden_size, self.output_dim)
-            fc1_weight[0, i, :, :], fc1_bias[0, i, :] = fc1.weight, fc1.bias
-            fc2_weight[0, i, :, :], fc2_bias[0, i, :] = fc2.weight.t(), fc2.bias[:fc2_bias.size(-1)]
-
-        self.register_parameter(name='batched_fc1_w', param=torch.nn.Parameter(fc1_weight.squeeze(0)))
-        self.register_parameter(name='batched_fc2_w', param=torch.nn.Parameter(fc2_weight.squeeze(0)))
-        self.register_parameter(name='batched_fc1_bias', param=torch.nn.Parameter(fc1_bias.squeeze(0)))
-        self.register_parameter(name='batched_fc2_bias', param=torch.nn.Parameter(fc2_bias.squeeze(0)))
+    def reset_parameters(self):
+        with torch.no_grad():
+            for i in range(self.batched_fc1_w.size(0)):
+                fc1 = torch.nn.Linear(self.model_dim, self.hidden_size)
+                fc2 = torch.nn.Linear(self.hidden_size, self.output_dim)
+                self.batched_fc1_w[i], self.batched_fc2_bias[i] = fc1.weight, fc1.bias
+                self.batched_fc2_w[i], self.batched_fc2_bias[i] = fc2.weight.t(), fc2.bias[:self.batched_fc2_bias.size(-1)]
 
     def extra_repr(self):
         return 'model_dim=%d, hidden_size=%d, output_dim=%d, local_experts=%d' % (
@@ -54,8 +53,10 @@ class FusedExpertsNetwork(torch.nn.Module):
 
         batched_fc1_w = self.batched_fc1_w
         batched_fc2_w = self.batched_fc2_w
-        batched_fc1_bias = self.batched_fc1_bias.unsqueeze(1)
-        batched_fc2_bias = self.batched_fc2_bias.unsqueeze(1)
+        if self.batched_fc1_bias is not None:
+            batched_fc1_bias = self.batched_fc1_bias.unsqueeze(1)
+        if self.batched_fc2_bias is not None:
+            batched_fc2_bias = self.batched_fc2_bias.unsqueeze(1)
 
         # Implementation of https://arxiv.org/pdf/2211.15841.pdf in Tutel v0.3.x
         #   which benifits decoder inference on single-GPU if num_local_experts >= 2
@@ -64,17 +65,21 @@ class FusedExpertsNetwork(torch.nn.Module):
             sparse_groups = torch.div(ctx.dispatch_count + (sparse_size - 1), sparse_size, rounding_mode='floor')
             sparse_groups = torch.minimum(sparse_groups, torch.tensor(x.size(1) // sparse_size, dtype=torch.int32, device=x.device))
             y = torch.ops.tutel_ops.sparse_bmm_infer(x, batched_fc1_w, sparse_groups, True, sparse_size)
-            y = torch.add(y, batched_fc1_bias)
+            if self.batched_fc1_bias is not None:
+                y = torch.add(y, batched_fc1_bias)
             y = self.activation_fn(y)
             y = torch.ops.tutel_ops.sparse_bmm_infer(y, batched_fc2_w, sparse_groups, False, sparse_size)
-            y = torch.add(y, batched_fc2_bias)
+            if self.batched_fc2_bias is not None:
+                y = torch.add(y, batched_fc2_bias)
             return y
 
         if ctx.adaptive_degree == 0:
             batched_fc1_w = net.zero_gather(batched_fc1_w, group=ctx.group).view(ctx.num_global_experts, -1, batched_fc1_w.size(2))
             batched_fc2_w = net.zero_gather(batched_fc2_w, group=ctx.group).view(ctx.num_global_experts, -1, batched_fc2_w.size(2))
-            batched_fc1_bias = net.zero_gather(batched_fc1_bias, group=ctx.group).view(ctx.num_global_experts, 1, -1)
-            batched_fc2_bias = net.zero_gather(batched_fc2_bias, group=ctx.group).view(ctx.num_global_experts, 1, -1)
+            if self.batched_fc1_bias is not None:
+                batched_fc1_bias = net.zero_gather(batched_fc1_bias, group=ctx.group).view(ctx.num_global_experts, 1, -1)
+            if self.batched_fc2_bias is not None:
+                batched_fc2_bias = net.zero_gather(batched_fc2_bias, group=ctx.group).view(ctx.num_global_experts, 1, -1)
         else:
             if ctx.sharded_count > 1:
                 group_size = ctx.sharded_count // ctx.adaptive_degree
@@ -82,20 +87,26 @@ class FusedExpertsNetwork(torch.nn.Module):
                     ffn_zero_group = net.create_groups_from_world(group_count=-group_size).model_group
                     batched_fc1_w = net.zero_gather(batched_fc1_w, group=ffn_zero_group).view(1, -1, ctx.model_dim)
                     batched_fc2_w = net.zero_gather(batched_fc2_w, group=ffn_zero_group).view(1, -1, self.output_dim)
-                    batched_fc1_bias = net.zero_gather(batched_fc1_bias, group=ffn_zero_group).view(1, 1, -1)
+                    if self.batched_fc1_bias is not None:
+                        batched_fc1_bias = net.zero_gather(batched_fc1_bias, group=ffn_zero_group).view(1, 1, -1)
 
-                batched_fc2_bias = net.zero_gather(batched_fc2_bias, group=net.create_groups_from_world(group_count=ctx.num_global_experts).model_group)
-                batched_fc2_bias = batched_fc2_bias.view(1, 1, -1)
+                if self.batched_fc2_bias is not None:
+                    batched_fc2_bias = net.zero_gather(batched_fc2_bias, group=net.create_groups_from_world(group_count=ctx.num_global_experts).model_group)
+                    batched_fc2_bias = batched_fc2_bias.view(1, 1, -1)
 
-                if ctx.adaptive_degree > 1:
-                    batched_fc2_bias = torch.mul(batched_fc2_bias, 1.0 / ctx.adaptive_degree)
+                    if ctx.adaptive_degree > 1:
+                        batched_fc2_bias = torch.mul(batched_fc2_bias, 1.0 / ctx.adaptive_degree)
 
-        if batched_fc2_bias.size(-1) != self.output_dim:
+        if self.batched_fc2_bias is not None and batched_fc2_bias.size(-1) != self.output_dim:
             batched_fc2_bias = batched_fc2_bias[:, :, :self.output_dim]
 
-        y = torch.add(torch.matmul(x, batched_fc1_w.permute(0, 2, 1)), batched_fc1_bias)
+        y = torch.matmul(x, batched_fc1_w.permute(0, 2, 1))
+        if self.batched_fc1_bias is not None:
+            y = torch.add(y, batched_fc1_bias)
         y = self.activation_fn(y)
-        y = torch.add(torch.matmul(y, batched_fc2_w), batched_fc2_bias)
+        y = torch.matmul(y, batched_fc2_w)
+        if self.batched_fc2_bias is not None:
+            y = torch.add(y, batched_fc2_bias)
         return y
 
 

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -43,8 +43,8 @@ class FusedExpertsNetwork(torch.nn.Module):
                 self.batched_fc2_w[i], self.batched_fc2_bias[i] = fc2.weight.t(), fc2.bias[:self.batched_fc2_bias.size(-1)]
 
     def extra_repr(self):
-        return 'model_dim=%d, hidden_size=%d, output_dim=%d, local_experts=%d' % (
-            self.batched_fc1_w.size(2), self.batched_fc1_w.size(1), self.batched_fc2_w.size(2), self.batched_fc1_w.size(0)
+        return 'model_dim=%d, hidden_size=%d, output_dim=%d, local_experts=%d. has bias=%s.' % (
+            self.batched_fc1_w.size(2), self.batched_fc1_w.size(1), self.batched_fc2_w.size(2), self.batched_fc1_w.size(0), self.batched_fc1_bias is not None
         )
 
     def forward(self, x, ctx):

--- a/tutel/experts/ffn.py
+++ b/tutel/experts/ffn.py
@@ -47,7 +47,7 @@ class FusedExpertsNetwork(torch.nn.Module):
                     self.batched_fc2_bias[i] = fc2.bias[:self.batched_fc2_bias.size(-1)]
 
     def extra_repr(self):
-        return 'model_dim=%d, hidden_size=%d, output_dim=%d, local_experts=%d. has bias=%s.' % (
+        return 'model_dim=%d, hidden_size=%d, output_dim=%d, local_experts=%d. has_bias=%s.' % (
             self.batched_fc1_w.size(2), self.batched_fc1_w.size(1), self.batched_fc2_w.size(2), self.batched_fc1_w.size(0), self.batched_fc1_bias is not None
         )
 

--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -70,14 +70,10 @@ class MOELayer(torch.nn.Module):
             assert buff_name in state_dict, "Could not find parameter `%s` in state_dict." % buff_name
             if state_dict[buff_name].numel() == param.numel():
                 state_dict[buff_name] = state_dict[buff_name].view(param.shape)
-
-        self._num_global_experts = state_dict.pop('_num_global_experts')
         return super()._load_from_state_dict(state_dict, prefix, *args, **kwargs)
 
     def state_dict(self, destination=None, prefix='', keep_vars=False):
-        state_dict = super().state_dict(destination, prefix, keep_vars)
-        state_dict['_num_global_experts'] = self._num_global_experts
-        return state_dict
+        return super().state_dict(destination, prefix, keep_vars)
 
     @property
     def num_global_experts(self):
@@ -116,7 +112,7 @@ class MOELayer(torch.nn.Module):
         self.skip_moe = (int(os.environ.get('SKIP_MOE', '0')) != 0)
 
         self.num_local_experts = experts.pop('count_per_node', 1)
-        self._num_global_experts = MOELayer.global_expert_count(self.num_local_experts, self.group)
+        self.register_buffer('_num_global_experts', torch.tensor(MOELayer.global_expert_count(self.num_local_experts, self.group)))
 
         self.world_size = C.get_world_size(self.group)
         if self.num_global_experts < self.world_size:


### PR DESCRIPTION
Clone of https://github.com/microsoft/tutel/pull/210 but this leaves `_num_global_experts` as a registered buffer.

This PR
- Clean up __init__ / param init for FusedExpertsNetwork
- enable FusedExpertsNetwork to run without bias


Notes:
All tensor naming is still the same. If bias=True the generated state dict will be the same. All old state dicts can still be loaded.

This only makes layer init more conventional (along with using a more conventional `reset_parameters`) eg [torch.nn.Linear layer](https://pytorch.org/docs/stable/_modules/torch/nn/modules/linear.html#Linear).
(Standard PyTorch attaches params in \_\_init__ instead of in an auxiliary `self.update(ctx)` fn. After params are attached standard PyTorch calls `reset_parameters`.)

I just moved parameter init, I didn't change how init happens. The seeding is unchanged. The parameters are still [initialized in an nn.Linear layer and copied over](https://github.com/microsoft/tutel/pull/210/files#diff-ef4f1a9825a158f9757d26b3d77b010752b142e479e9167c55b501829056d93aR40-R47) 