### PR TITLE
Improve bandwidth_test example accuracy

### DIFF
--- a/tutel/examples/bandwidth_test.py
+++ b/tutel/examples/bandwidth_test.py
@@ -12,7 +12,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument('--device', type=str, default='cuda' if torch.cuda.is_available() else 'cpu')
 parser.add_argument('--size_mb', type=int, default=256)
 parser.add_argument('--loop', type=int, default=50)
-
+parser.add_argument('--warmup', type=int, default=5, help='Number of warmup iterations')
 args = parser.parse_args()
 
 parallel_env = system.init_data_model_parallel(backend='nccl' if args.device == 'cuda' else 'gloo')
@@ -25,24 +25,60 @@ if args.device == 'cuda':
 else:
   wait = lambda: time.perf_counter()
 
+# Warmup phase (excluded from any measurement)
 with torch.no_grad():
+  for _ in range(args.warmup):
+    net.simple_all_to_all(x.view(parallel_env.global_size, -1))
+    net.simple_all_reduce(x.view(-1), inplace=True)
+    net.simple_all_gather(x.view(parallel_env.global_size, -1)[parallel_env.global_rank])
+    net.simple_reduce_scatter(x.view(parallel_env.global_size, -1))
+
+# Measurement phase - accumulate times and compute average bandwidth
+with torch.no_grad():
+  total_time_a2a = 0.0
+  total_time_ar = 0.0
+  total_time_ag = 0.0
+  total_time_rs = 0.0
+
   for _ in range(args.loop):
+    # AllToAll
     t0 = wait()
     net.simple_all_to_all(x.view(parallel_env.global_size, -1))
     t1 = wait()
-    parallel_env.dist_print(f'AllToAll bandwidth across {parallel_env.global_size} node(s) = %.4f GB/s' % ((x.numel() * 4) * 1e-9 / (t1 - t0)))
+    total_time_a2a += (t1 - t0)
+    
+    # AllReduce
     t0 = wait()
     net.simple_all_reduce(x.view(-1), inplace=True)
     t1 = wait()
-    parallel_env.dist_print(f'AllReduce bandwidth across {parallel_env.global_size} node(s) = %.4f GB/s' % ((x.numel() * 4) * 1e-9 / (t1 - t0)))
+    total_time_ar += (t1 - t0)
+    
+    # AllGather
     t0 = wait()
     net.simple_all_gather(x.view(parallel_env.global_size, -1)[parallel_env.global_rank])
     t1 = wait()
-    parallel_env.dist_print(f'AllGather bandwidth across {parallel_env.global_size} node(s) = %.4f GB/s' % ((x.numel() * 4) * 1e-9 / (t1 - t0)))
+    total_time_ag += (t1 - t0)
+
+    # ReduceScatter
     t0 = wait()
     net.simple_reduce_scatter(x.view(parallel_env.global_size, -1))
     t1 = wait()
-    parallel_env.dist_print(f'ReduceScatter bandwidth across {parallel_env.global_size} node(s) = %.4f GB/s' % ((x.numel() * 4) * 1e-9 / (t1 - t0)))
-    parallel_env.dist_print('')
-    time.sleep(0.5)
+    total_time_rs += (t1 - t0)
 
+  # Calculate and print the average bandwidth for each collective
+  parallel_env.dist_print(
+    f'AllToAll average bandwidth across {parallel_env.global_size} node(s) = '
+    f'{((x.numel() * 4) * 1e-9 * args.loop) / total_time_a2a:.4f} GB/s'
+  )
+  parallel_env.dist_print(
+    f'AllReduce average bandwidth across {parallel_env.global_size} node(s) = '
+    f'{((x.numel() * 4) * 1e-9 * args.loop) / total_time_ar:.4f} GB/s'
+  )
+  parallel_env.dist_print(
+    f'AllGather average bandwidth across {parallel_env.global_size} node(s) = '
+    f'{((x.numel() * 4) * 1e-9 * args.loop) / total_time_ag:.4f} GB/s'
+  )
+  parallel_env.dist_print(
+    f'ReduceScatter average bandwidth across {parallel_env.global_size} node(s) = '
+    f'{((x.numel() * 4) * 1e-9 * args.loop) / total_time_rs:.4f} GB/s'
+  )


### PR DESCRIPTION
The original bandwidth_test example provided inaccurate results compared to nccl_tests, despite using the same NCCL API, due to a time.sleep(0.5) in each loop causing GPU state switching. This impacted performance measurement.

Changes made:

1. Removed time.sleep(0.5) from the loop to prevent GPU idle/busy switching.
2. Calculate average bandwidth per operation type for more accurate results.
3. Added warmup iterations to ensure consistent GPU performance.

These changes enhance test reliability and accuracy.