### PR TITLE
Fix: Correctly handle capacity_factor=0 in MOELayer forward pass

### DIFF
--- a/tutel/impls/moe_layer.py
+++ b/tutel/impls/moe_layer.py
@@ -305,7 +305,7 @@ class MOELayer(torch.nn.Module):
             return logits.dtype, extract_critical(scores,
                 top_k = top_k,
                 loss_fn = _loss_fn,
-                capacity_factor = capacity_factor or gctx.capacity_factor,
+                capacity_factor = capacity_factor if capacity_factor is not None else gctx.capacity_factor,
                 batch_prioritized_routing = self.batch_prioritized_routing,
                 normalize_gate = self.normalize_gate,
                 group = self.group,


### PR DESCRIPTION
Hey, Hope you are doing well.

I noticed a bug during my research where setting `capacity_factor = 0` during the forward pass is impossible if the model was initialized with a non-zero `capacity_factor`. Here is the explanation and the suggested fix.

## Where?
[moe_layer.py](https://github.com/microsoft/Tutel/blob/main/tutel/impls/moe_layer.py) at [Line 308](https://github.com/microsoft/Tutel/blob/25d4c9aec3f5179c29a43558bb4b4f2c9b6319e0/tutel/impls/moe_layer.py#L308)

## The Bug 
In `MOELayer.forward()`, the `capacity_factor` is determined by the following line:

`capacity_factor = capacity_factor or gctx.capacity_factor`

0 is a falsy value in Python; if a user passes `capacity_factor=0` to the `forward()` method, the expression incorrectly evaluates to `gctx.capacity_factor` instead of the intended `0`. This prevents users from dynamically enabling "dropless MoE" at runtime, which is a key feature.

## The Fix
I propose changing the line to explicitly check for `None`, which correctly handles all cases, including 0:

`capacity_factor = capacity_factor if capacity_factor is not None else gctx.capacity_factor`

This ensures that an explicitly passed 0 is honored, while still falling back to the gate's default capacity factor when the argument is not provided (None). This change aligns the code’s behavior with the documentation and examples that utilize "dropless MoE".

Thank you, Let me know what you think.

All the best,
Moien